### PR TITLE
fix: no need to use generatePath in generateAppUrl

### DIFF
--- a/src/hooks/useEventData.ts
+++ b/src/hooks/useEventData.ts
@@ -21,7 +21,7 @@ export const useCreateEventData = () => {
     switch (eventName) {
       case EVENTS.STORY_LOADED: {
         const eventData: EventData[typeof eventName] = {
-          url: generateAppUrl(location.pathname, params, searchParams, location.hash),
+          url: generateAppUrl(location.pathname, searchParams, location.hash),
           path: location.pathname,
           routeParams: params,
           searchParams,
@@ -36,7 +36,7 @@ export const useCreateEventData = () => {
 
       case EVENTS.NAVIGATION: {
         const eventData: EventData[typeof eventName] = {
-          url: generateAppUrl(location.pathname, params, searchParams, location.hash),
+          url: generateAppUrl(location.pathname, searchParams, location.hash),
           path: location.pathname,
           routeParams: params,
           searchParams,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,13 +1,10 @@
-import { generatePath } from "react-router-dom";
 import {EventData, NavigationEventsValues} from "./typings";
 
 export const generateAppUrl = (
-  path: Parameters<typeof generatePath>[0],
-  params?: Parameters<typeof generatePath>[1],
+  pathname: string,
   search?: ConstructorParameters<typeof URLSearchParams>[0],
   hash?: string,
 ) => {
-  const pathname = generatePath(path, params);
   const queryString = search && Object.keys(search).length > 0 ? `?${new URLSearchParams(search).toString()}` : '';
   const hashString = hash ? hash : '';
 

--- a/stories/Header.js
+++ b/stories/Header.js
@@ -11,12 +11,12 @@ export const Header = ({ user, onLogin: onUserLogin, onLogout: onUserLogout, onC
   const navigate = useNavigate();
 
   const onLogin = () => {
-    navigate(generateAppUrl('/', undefined, { login: 'true' }));
+    navigate(generateAppUrl('/', { login: 'true' }));
     onUserLogin && onUserLogin();
   }
 
   const onLogout = () => {
-    navigate(generateAppUrl('/', undefined, { logout: 'true' }));
+    navigate(generateAppUrl('/', { logout: 'true' }));
     onUserLogout && onUserLogout();
   }
 

--- a/stories/Page.stories.js
+++ b/stories/Page.stories.js
@@ -2,10 +2,12 @@ import React from 'react';
 
 import { Page } from './Page';
 import * as HeaderStories from './Header.stories';
+import { withRouter } from '../dist/esm';
 
 export default {
   title: 'Example/Page',
   component: Page,
+  decorators: [withRouter],
 };
 
 const Template = (args) => <Page {...args} />;


### PR DESCRIPTION
in case like param value have `:` like this it will error in `generateAppUrl()`.

```ts
reactRouter: {
      routePath: "/:someParam",
      routeParams: { someParam: ":someValue" },
},
```

because our `location.pathname` will become `/:someValue` and in `useCreateEventData()` we pass it to `generateAppUrl()` that will call `generatePath()` like this.

```ts
generatePath('/:someValue', { someParam: ':someValue' })
```

<img width="859" alt="Screen Shot 2565-08-02 at 01 00 56" src="https://user-images.githubusercontent.com/42176460/182212632-22709d95-5328-438e-a8e3-9f124a51f875.png">

to fix it i think we just need `pathname` from `location.pathname` in `generateAppUrl()`.

sorry for my bad english 😄 .