### PR TITLE
fix(panel): restore -key- prop

### DIFF
--- a/src/manager.tsx
+++ b/src/manager.tsx
@@ -42,6 +42,6 @@ addons.register(ADDON_ID, (api) => {
       return `React Router${suffix}`;
     },
     match: ({ viewMode }) => viewMode === 'story',
-    render: ({ active }) => <Panel active={active || false} api={api} />,
+    render: ({ active, key }) => <Panel active={active || false} key={key} api={api} />,
   });
 });


### PR DESCRIPTION
Hey, can we bring back key prop?

Reverts https://github.com/buberdds/storybook-addon-react-router-v6/commit/6e129c7b57d212ecf5ceb65766be8291b076775c

When I upgrade to `2.0.0` storybook throws 

```
chunk-3FAXWWKG.js:3 Warning: Each child in a list should have a unique "key" prop.

Check the top-level render call using <Styled(div)>. See https://fb.me/react-warning-keys for more information.
    in pt
    in Unknown
    in Unknown
    in Unknown
    in Unknown (created by ManagerConsumer)
    in ManagerConsumer (created by Panel2)
    in Panel2 (created by Layout)
    in div (created by Styled(div))
    in Styled(div) (created by Panel)
    in Panel (created by Layout)
    in div (created by Styled(div))
    in Styled(div) (created by Main)
    in div (created by Styled(div))
    in Styled(div) (created by Main)
    in Main (created by Layout)
    in Layout (created by WithTheme(Layout))
    in WithTheme(Layout)
    in Unknown (created by App)
    in div (created by Styled(div))
    in Styled(div) (created by App)
    in App
    in ThemeProvider
    in Unknown (created by ManagerConsumer)
    in ManagerConsumer (created by Manager)
    in EffectOnMount (created by Manager)
    in Manager (created by QueryLocation)
    in QueryLocation (created by Main2)
    in Main2 (created by Root4)
    in Router (created by LocationProvider)
    in LocationProvider (created by Root4)
    in HelmetProvider (created by Root4)
    in Root4
```

when I bring back key prop warning disappears. 