### PR TITLE
fix(InformationBanner): clean up css syntax

### DIFF
--- a/src/features/panel/components/InformationBanner.tsx
+++ b/src/features/panel/components/InformationBanner.tsx
@@ -1,7 +1,7 @@
 import { styled } from '@storybook/theming';
 
 export const InformationBanner = styled.p({
-  'background': '#ffebba',
-  'padding': '5px',
-  'margin-top': 0,
+  background: '#ffebba',
+  padding: '5px',
+  marginTop: 0,
 });


### PR DESCRIPTION
Thanks for `v2.0.1`! It fixes my [prev issue](https://github.com/JesusTheHun/storybook-addon-react-router-v6/pull/43). There is one, new minor warning after 2.0.1 release.  `Using kebab-case for css properties in objects is not supported.` 