### PR TITLE
fix: remove pnpm-only preinstall from published package

### DIFF
--- a/packages/storybook-addon-remix-react-router/package.json
+++ b/packages/storybook-addon-remix-react-router/package.json
@@ -45,7 +45,6 @@
     "*.d.ts"
   ],
   "scripts": {
-    "preinstall": "npx only-allow pnpm",
     "clean": "rimraf ./dist",
     "prebuild": "pnpm run clean",
     "build": "tsup",


### PR DESCRIPTION
## Why

`packages/storybook-addon-remix-react-router/package.json` carries
`"preinstall": "npx only-allow pnpm"`, which runs inside consumer
projects whenever someone installs the addon. Installs have been
reported to break on #87, including the `npm ci` failure in the
comments.

## Minimal reproduction

https://github.com/craigmorrison/storybook-rr-preinstall-repro

```sh
cd consumer-npm10
npx -y -p npm@10.9.3 npm install -D storybook-addon-remix-react-router
```

Install aborts at the preinstall step.

## Why it's safe

The monorepo has the same preinstall in two places:

- **Root `package.json`** — `"private": true`, never published.
  Enforces pnpm for contributors cloning this repo.
- **Published `package.json`** (this change) — runs inside consumers' projects.

Only the second is removed. `npm install` at the repo root still
blocks as intended; contributor enforcement is unchanged.

It also aligns the package with the README, which already instructs
`npm i -D storybook-addon-remix-react-router`.

Refs #87